### PR TITLE
Fix README spacing

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ bash oneclick_installer.sh
 
 1. **Restart GNOME Shell**
 
-   a.Shortcut (For X11) :
+   a. Shortcut (For X11):
    
    ```bash
    Alt + F2, then type: r


### PR DESCRIPTION
## Summary
- fix space after `a.` in README

## Testing
- `grep -n Shortcut -n README.md`

------
https://chatgpt.com/codex/tasks/task_e_687e1f8fc6e88320869c78cb4fe75266